### PR TITLE
1e versie aanpassing WEH/eIDAS

### DIFF
--- a/PvE deel 1
+++ b/PvE deel 1
@@ -234,35 +234,33 @@ wordt gerefereerd, zijn de volgende:
 
  
 
-[1]     Wet Elektronische Handtekeningen
-Wet van 8 mei 2003 tot aanpassing van Boek 3 en Boek 6 van het Burgerlijk
-Wetboek, de Telecommunicatiewet en de Wet op de economische delicten inzake
-elektronische handte­keningen ter uitvoering van de richtlijn nr. 1999/93/EG
-van het Europees Parlement en de Raad van de Europese Unie van 13 december 1999
-betreffende een gemeenschappelijk kader voor elektronische handtekeningen (PbEG
-L 13).
+[1]     Uitvoering EU-verordening elektronische identiteiten en vertrouwensdiensten 
+Wet van 21 december 2016 tot wijziging van de Telecommunicatiewet, de Boeken 3 en 6 van
+het Burgerlijk Wetboek, de Algemene wet bestuursrecht alsmede daarmee
+samenhangende wijzigingen van andere wetten in verband met de uitvoering van
+EU-verordening elektronische identiteiten en vertrouwensdiensten. 
 
+[2]     Besluit Vertrouwensdiensten
+Besluit van 22 februari 2017, houdende vaststelling van eisen inzake verlening van
+vertrouwensdiensten, tot intrekking van het Besluit elektronische
+handtekeningen en tot aanpassing van enige andere besluiten
  
 
-[2]     Besluit Elektronische Handtekeningen
-Besluit van 8 mei 2003, houdende de vaststelling van eisen voor het verlenen
-van diensten voor elektronische handtekeningen.
+[3]     Regeling Vertrouwensdiensten 
+Regeling van de Minister van Economische Zaken van 24 februari 2017, nr. WJZ/17028856,
+in overeenstemming met de Minister van Financiën en de Minister van
+Infrastructuur en Milieu, tot vaststelling van procedurele bepalingen inzake de
+aanvraag tot certificerende instelling van gekwalificeerde middelen, de
+aanvraag tot toekenning van de status gekwalificeerd en inzake de vertrouwenslijst,
+tot intrekking van de Regeling elektronische handtekeningen en van de Regeling
+vertrouwenslijst en tot wijziging van een aantal regelingen als gevolg van de
+inwerkingtreding van de eIDAS-verordening
 
- 
-
-[3]     Regeling Elektronische Handtekeningen, 6
-mei 2003 nr. WJZ/03/02263 Regeling van de Staatssecretaris van Economische
-Zaken houdende nadere regels met be­trekking tot elektronische handtekeningen.
-
- 
-
-[4]     Beleidsregel aanwijzing
-certificatieorganisaties elektronische handtekeningen, 6 mei 2003 nr.
-WJZ/03/02264
-Beleidsregel van de Staatssecretaris van Economische Zaken met betrekking tot
-de aanwij­zing van organisaties die certificatiedienst-verleners toetsen op de
-overeenstemming met de bij of krachtens de Telecommunicatiewet gestelde eisen,
-op grond van artikel 18.16 van de Telecommunicatiewet.
+[4]     eIDAS verordening
+Verordening (EU) nr. 910/2014 van het Europees Parlement en de Raad van 23 juli 2014
+betreffende elektronische identificatie en vertrouwensdiensten voor
+elektronische transacties in de interne markt en tot intrekking van Richtlijn
+1999/93/EG
 
  
 


### PR DESCRIPTION
Verwijzingen naar de Wet Elektronische Handtekeningen en de richtlijn Elektronische Handtekeningen verwijderen uit het PvE en vervangen door de nieuwe relevante standaarden (eIDAS)